### PR TITLE
Review: #97 FIX: Dashboard is visible next to all pages for all routes

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,21 +1,15 @@
-import { Outlet } from 'react-router';
-import { HeaderNav } from '../features/shared/components/HeaderNav';
-import RoleSwitch from '../pages/RoleSwitch';
-import Menu from '../features/shared/components/Menu';
-
+import { Outlet } from "react-router";
+import { HeaderNav } from "../features/shared/components/HeaderNav";
+import Menu from "../features/shared/components/Menu";
 
 export function App() {
-
   return (
     <>
       <HeaderNav />
       <div className="master-row">
-      <Menu  />
-      <Outlet />
-
-      {/* used to chose compontents based on role */}
-      <RoleSwitch />
-            </div>
+        <Menu />
+        <Outlet />
+      </div>
     </>
   );
 }

--- a/src/css/global.css
+++ b/src/css/global.css
@@ -3,27 +3,25 @@
 }
 
 .main-wrapper {
-  padding-left:1rem;
-  padding-right:1rem;
-  padding-top:1rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 1rem;
   width: 100%;
   min-height: calc(100vh - var(--header-height));
   height: auto;
 }
 
+/* text */
+.bold {
+  font-weight: bold;
+}
 
-  /* text */
-  .bold {
-    font-weight: bold;
-  }
-
-  .text-gray {
-    color: var(--text-gray);
-  }
+.text-gray {
+  color: var(--text-gray);
+}
 
 .master-row {
   display: flex;
   flex-direction: row;
   gap: 1rem;
 }
-

--- a/src/pages/courseparticipant/CourseParticipants.css
+++ b/src/pages/courseparticipant/CourseParticipants.css
@@ -1,8 +1,3 @@
-main.course-participants-page {
-  background-color: var(--background-gray);
-
-  min-width: 100%;
-  min-height: 100vh;
-
-  padding: 1rem;
+.course-participants-title {
+  padding-block: 1rem;
 }

--- a/src/pages/courseparticipant/CourseParticipants.tsx
+++ b/src/pages/courseparticipant/CourseParticipants.tsx
@@ -6,7 +6,7 @@ export const CourseParticipants: React.FC = () => {
   const participants = useLoaderData() as IUserParticipants[];
 
   return (
-    <main className="course-participants-page">
+    <main className="main-wrapper">
       <h1 className="course-participants-title">Kursdeltagare</h1>
       <UserList users={participants} />
     </main>


### PR DESCRIPTION
This PR fixes the additional (unwanted) dashboard page which shows up next to every page. 
It also fixed the issue where CourseParticipants page didn't properly got contained inside of the parent container (main stretched outside of body where it overflowed).

NOTE: Preferably review #96 before this one, as this PR has merged commits from that branch (#80).